### PR TITLE
fix:update modify data use the right template

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,8 @@
 /*
  * @Author: mikey.zhaopeng
  * @Date:   2016-07-29 15:57:29
- * @Last Modified by: Eastegg
- * @Last Modified time: 2018-02-5 18:05:49
+ * @Last Modified by: caoweiju
+ * @Last Modified time: 2019-10-12 16:31:37
  */
 
 var vscode = require('vscode');
@@ -81,6 +81,7 @@ function activate(context) {
                 for (var i = 0; i < lineCount; i++) {
                     var linetAt = document.lineAt(i);
                     
+                    var lineTextOriginal = linetAt.text;
                     var line = linetAt.text;
                     line = line.trim();
                     if (line.startsWith("/*") && !line.endsWith("*/")) {//是否以 /* 开头
@@ -91,15 +92,30 @@ function activate(context) {
                         }
                         var range = linetAt.range;
                         if (line.indexOf('@Last\ Modified\ by') > -1) {//表示是修改人
+                            var replaceAuthorReg = /^(.*?)(@Last Modified by:)(\s*)(\S*)$/;
                             authorRange = range;
-                            authorText=' * @Last Modified by: ' + config.LastModifiedBy;
+                            if (replaceAuthorReg.test(lineTextOriginal)) {
+                                authorText = lineTextOriginal.replace(replaceAuthorReg, function(match, p1, p2, p3){
+                                    return p1+p2+p3+config.LastModifiedBy;
+                                });
+                            } else {
+                                authorText=' * @Last Modified by: ' + config.LastModifiedBy;
+                            }
                         } else if (line.indexOf('@Last\ Modified\ time') > -1) {//最后修改时间
                             var time = line.replace('@Last\ Modified\ time:', '').replace('*', '');
                             var oldTime = new Date(time);
                             var curTime = new Date();
                             var diff = (curTime - oldTime) / 1000;
+                            var replaceTimeReg = /^(.*?)(@Last Modified time:)(\s*)(.*)$/;
                             lastTimeRange = range;
-                            lastTimeText=' * @Last Modified time: ' + curTime.format("yyyy-MM-dd hh:mm:ss");
+                            var currTimeFormate = curTime.format("yyyy-MM-dd hh:mm:ss");
+                            if (replaceTimeReg.test(lineTextOriginal)) {
+                                lastTimeText = lineTextOriginal.replace(replaceTimeReg, function(match, p1, p2, p3){
+                                    return p1+p2+p3+currTimeFormate;
+                                });
+                            } else {
+                                lastTimeText=' * @Last Modified time: ' + currTimeFormate;
+                            }
                         }
                         if (!comment) {
                             break;//结束


### PR DESCRIPTION
fix case:
````
// default header 默认的头部如下
/*
 * @Author: {author} 
 * @Date: {createTime} 
 * @Last Modified by: {lastModifiedBy} 
 * @Last Modified time: {updateTime} 
 */

// change default formate, delete the space before * 自定义修改了模板如下删除了空格
/*
* @Author: caoweiju
* @Date: 2019-10-12 15:42:20
* @Last Modified by: caoweiju
* @Last Modified time: 2019-10-12 15:58:42
*/

// after save file, still get the space before *  修改保存后，模板中删除的空格还是被保存了
/*
* @Author: caoweiju
* @Date: 2019-10-12 15:42:20
 * @Last Modified by: caoweiju
 * @Last Modified time: 2019-10-12 15:59:42
*/
````
在使用自己定义的模板的时候，发现每次保存的时候插入的 author 和 time 对应的行内容都会被写死，但是这显然不符合一些情况，我们希望能够保存用户的格式，只更换time时间和author用户名，【当然如果这两行内容被修改的完全和模板内容不匹配的话，我们很难获取到时间和用户名的部分，特别是多人协作修改的author字段，所以这里只修改了和默认模式类似的情况，否则走原有逻辑】